### PR TITLE
Add support for gnome-shell 41 - 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,9 @@
   "version": 1,
   "url": "https://github.com/coffeverton/weekend-o-meter",
   "shell-version": [
-    "3.38"
+    "44",
+    "43",
+    "42",
+    "41"
   ]
 }


### PR DESCRIPTION
I added the missing shell-version for this extension.

I tested it under 43 and 44.
But 41 and 42 should be fine as well.