### PR TITLE
Add gnome 45 support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -17,22 +17,15 @@
  */
 
 /* exported init */
-
-const GETTEXT_DOMAIN = 'weekendometer-extension';
-
-const { GObject, St } = imports.gi;
-
-const Gettext = imports.gettext.domain(GETTEXT_DOMAIN);
-const _ = Gettext.gettext;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
 const Indicator = GObject.registerClass(
 class Indicator extends PanelMenu.Button {
     _init() {
-        super._init(0.0, _('Weekendometer'));
+        super._init(0.0, 'Weekendometer');
 
         let box = new St.BoxLayout({ style_class: 'panel-status-menu-box' });
         box.add_child(new St.Icon({style_class: this._getClassName()}));
@@ -108,8 +101,6 @@ class Indicator extends PanelMenu.Button {
 class Extension {
     constructor(uuid) {
         this._uuid = uuid;
-
-        ExtensionUtils.initTranslations(GETTEXT_DOMAIN);
     }
 
     enable() {
@@ -126,3 +117,5 @@ class Extension {
 function init(meta) {
     return new Extension(meta.uuid);
 }
+
+export default Extension;

--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,7 @@
   "url": "https://github.com/coffeverton/weekend-o-meter",
   "shell-version": [
     "3.38",
+    "45",
     "44",
     "43",
     "42",

--- a/metadata.json
+++ b/metadata.json
@@ -5,11 +5,6 @@
   "version": 1.1,
   "url": "https://github.com/coffeverton/weekend-o-meter",
   "shell-version": [
-    "3.38",
-    "45",
-    "44",
-    "43",
-    "42",
-    "41"
+    "45"
   ]
 }


### PR DESCRIPTION
Hey, this PR adds support for gnome 45 and is breaking for lower gnome versions!

closes #2

According to [this section](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#metadata) in the port guide all shell-versions lower than 45 should be removed from the extension.
To support older gnome version:
> You can still support more than one GNOME version, but you will have to upload different versions to [extensions.gnome.org](https://extensions.gnome.org/) for pre- and post-45 support.

Reference: https://blogs.gnome.org/shell-dev/2023/09/02/extensions-in-gnome-45/

Have a nice day, and thank you for maintaining this great extension. 