### PR TITLE
GNOME 49 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "version": 1.1,
   "url": "https://github.com/coffeverton/weekend-o-meter",
   "shell-version": [
-    "45",
-    "46"
+    "48",
+    "49"
   ]
 }


### PR DESCRIPTION
versions prior to 48 are no longer supported
https://release.gnome.org/calendar/#branches